### PR TITLE
Add line / block cursor config option

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -191,6 +191,19 @@ let &statusline = s:statusline_expr()
 let mapleader=" "
 let maplocalleader=" "
 
+" Use a line cursor within insert mode and a block cursor everywhere else.
+"
+" Reference chart of values:
+"   Ps = 0  -> blinking block.
+"   Ps = 1  -> blinking block (default).
+"   Ps = 2  -> steady block.
+"   Ps = 3  -> blinking underline.
+"   Ps = 4  -> steady underline.
+"   Ps = 5  -> blinking bar (xterm).
+"   Ps = 6  -> steady bar (xterm).
+let &t_SI = "\e[6 q"
+let &t_EI = "\e[2 q"
+
 set autoindent
 set autoread
 set backspace=indent,eol,start

--- a/c/Users/Nick/AppData/Local/Packages/Microsoft.WindowsTerminal_8wekyb3d8bbwe/LocalState/settings.json
+++ b/c/Users/Nick/AppData/Local/Packages/Microsoft.WindowsTerminal_8wekyb3d8bbwe/LocalState/settings.json
@@ -17,7 +17,7 @@
             // Put settings here that you want to apply to all profiles
             "colorScheme": "Gruvbox Dark",
             "cursorColor": "#ffb261",
-            "cursorShape": "vintage",
+            "cursorShape": "filledBox",
             "fontFace": "Consolas",
             "fontSize": 9,
             "padding": "1, 1, 1, 1",


### PR DESCRIPTION
This is a massive quality of life improvement even if your terminal
doesn't support dynamically changing the color of the character under
the block to ensure it's always visible.